### PR TITLE
Update README.md CLI installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Harbinger stores "candles" of prices of assets. Specifically, each data point fo
 The easiest way to get started with Harbinger is to install and use the [Harbinger CLI](https://github.com/tacoinfra/harbinger-cli):
 
 ```shell
-$ npm i -g harbinger
+$ npm i -g @tacoinfra/harbinger-cli
 $ harbinger --help
 ```
 


### PR DESCRIPTION
Looks like the installation instructions here don't match the one's at: https://github.com/tacoinfra/harbinger-cli. I downloaded this package globally and wasn't getting `harbinger: command not found`